### PR TITLE
fix: Update branch name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The deploy action only triggers on a push to `main` branch, but the main branch for this project is called `master`.